### PR TITLE
update: hsltorgb converter function

### DIFF
--- a/src/converters/hsltorgb.js
+++ b/src/converters/hsltorgb.js
@@ -11,9 +11,16 @@
  * @param {Array} arr The HSL value of the color to be converted
  * @returns The samd color in RGB color space
  */
-const convertHslToRgb = function (arr) {
-	let [h, s, l] = [...arr];
-	let r, g, b, r_, g_, b_;
+const convertHslToRgb = function (val, f = "array") {
+	let h, s, l, r, g, b, r_, g_, b_;
+
+	if (typeof val === "string")
+		[h, s, l] = val
+			.split("(")[1]
+			.split(")")[0]
+			.split(", ")
+			.map((v) => parseInt(v));
+	if (Array.isArray(val)) [h, s, l] = [...val];
 
 	s = s / 100;
 	l = l / 100;
@@ -35,7 +42,8 @@ const convertHslToRgb = function (arr) {
 	g = Math.round((g_ + m) * 255);
 	b = Math.round((b_ + m) * 255);
 
-	return [r, g, b];
+	if (f === "string") return `RGB(${r}, ${g}, ${b})`;
+	else return [r, g, b];
 };
 
 export default convertHslToRgb;

--- a/tests/converters.test.js
+++ b/tests/converters.test.js
@@ -1,12 +1,12 @@
 import { hexToHsl, hexToRgb, rgbToHex, rgbToHsl, hslToHex, hslToRgb } from "../src/color";
 
 const hexStr = "#DA4953",
-	hexStr2 = "#186460",
+	hexStr2 = "#18635F",
 	rgbStr = "RGB(218, 73, 83)",
-	rgbStr2 = "RGB(24, 100, 96)",
+	rgbStr2 = "RGB(24, 99, 95)",
 	rgbStr3 = "RGB(100, 75, 210)",
 	rgbArr = [218, 73, 83],
-	rgbArr2 = [24, 100, 96],
+	rgbArr2 = [24, 99, 95],
 	rgbArr3 = [100, 75, 210],
 	hslStr = "HSL(356, 66%, 57%)",
 	hslStr2 = "HSL(177, 61%, 24%)",
@@ -48,5 +48,31 @@ describe("convert color from rgb to hex", () => {
 
 	test("test 2: input as string", () => {
 		expect(rgbToHex(rgbStr)).toBe(hexStr);
+	});
+});
+
+describe("convert color from hsl to rgb", () => {
+	test("test 1: input and output as array", () => {
+		expect(hslToRgb(hslArr)).toEqual(rgbArr);
+		expect(hslToRgb(hslArr2)).toEqual(rgbArr2);
+		expect(hslToRgb(hslArr3)).toEqual(rgbArr3);
+	});
+
+	test("test 2: input as array and output as string", () => {
+		expect(hslToRgb(hslArr, "string")).toBe(rgbStr);
+		expect(hslToRgb(hslArr2, "string")).toBe(rgbStr2);
+		expect(hslToRgb(hslArr3, "string")).toBe(rgbStr3);
+	});
+
+	test("test 3: input as string and output as array", () => {
+		expect(hslToRgb(hslStr)).toEqual(rgbArr);
+		expect(hslToRgb(hslStr2)).toEqual(rgbArr2);
+		expect(hslToRgb(hslStr3)).toEqual(rgbArr3);
+	});
+
+	test("test 3: input and output as string", () => {
+		expect(hslToRgb(hslStr, "string")).toBe(rgbStr);
+		expect(hslToRgb(hslStr2, "string")).toBe(rgbStr2);
+		expect(hslToRgb(hslStr3, "string")).toBe(rgbStr3);
 	});
 });


### PR DESCRIPTION
Added the following to the hslToRgb converter function:

- Added support for passing strings as input
- Added support for selecting output format (string or array; default is array)
- Wrote unit tests for feature