### PR TITLE
Update: Hextohsl converter function

### DIFF
--- a/src/converters/hextohsl.js
+++ b/src/converters/hextohsl.js
@@ -5,12 +5,13 @@ import { default as rgbToHsl } from "./rgbtohsl.js";
 
 /**
  * A function that converts a color value from HEX to HSL
- * @param {string} hex The hexadecimal value of a color in the RGB color space
+ * @param {string} val The hexadecimal value of a color in the RGB color space
+ * @param {String} f The output format - string or array
  * @returns The same color in the HSL color space
  */
-const convertHextoHsl = function (hex) {
-	const rgb = hexToRgb(hex);
-	const hsl = rgbToHsl(rgb);
+const convertHextoHsl = function (val, f = "array") {
+	const rgb = hexToRgb(val);
+	const hsl = rgbToHsl(rgb, f);
 
 	return hsl;
 };

--- a/tests/converters.test.js
+++ b/tests/converters.test.js
@@ -96,3 +96,13 @@ describe("convert color from hex to rgb", () => {
 		expect(hexToRgb(hexStr, "string")).toBe(rgbStr);
 	});
 });
+
+describe("convert color from hex to hsl", () => {
+	test("test 1: output as array", () => {
+		expect(hexToHsl(hexStr)).toEqual(hslArr);
+	});
+
+	test("test 2: output as string", () => {
+		expect(hexToHsl(hexStr, "string")).toBe(hslStr);
+	});
+});


### PR DESCRIPTION
Added the following

- Support for selecting the output format (string or array - default is set to array)
- wrote unit tests